### PR TITLE
Fixed stack name

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -21,6 +21,6 @@ sam deploy \
     --region ${REGION} \
     --profile ${PROFILE}
 
-aws cloudformation describe-stacks --stack-name cw-alarm-to-slack --query 'Stacks[].Outputs' --profile ${PROFILE} --region ${REGION}
+aws cloudformation describe-stacks --stack-name cw-alarm-to-slack-${CLEANED_SLACK_CHANNEL} --query 'Stacks[].Outputs' --profile ${PROFILE} --region ${REGION}
 
 popd


### PR DESCRIPTION
I suppose this is the intentional behavior?

Not that it makes a huge difference, but otherwise describe-stacks throws an error